### PR TITLE
no need to handle "no connection" error in response; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/api-base",
-  "version": "0.2.3",
+  "version": "0.2.4-a1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -42,8 +42,6 @@ export const defaultErrorMessages: IErrorMessages = {
   [BuiltinApiErrorCode.CommandExecution]: lingual.commandExecution,
   [BuiltinApiErrorCode.RegionContainsContent]: lingual.regionContainsContent,
   [BuiltinApiErrorCode.ErrEnterpriseExpired]: lingual.enterpriseExpiredErrorInfo,
-
-  [BuiltinApiErrorCode.NoConnection]: lingual.noConnection,
 };
 
 export let globalErrorMessages = defaultErrorMessages;


### PR DESCRIPTION
前端出现的问题是 404 错误会被识别成"网络未找到", 原因是老代码当中会把 `code` 重置为 `0`. 但是按照代码逻辑, 网络未连接应该通过 `statusCode` 进行判断的, 所以在业务错误处理这里不需要识别这个代码.
