### PR TITLE
remove url-model dependencies; starting 0.3.0 alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/api-base",
-  "version": "0.2.7",
+  "version": "0.3.0-a1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -12,7 +12,6 @@
   "author": "JIMENGIO",
   "license": "ISC",
   "devDependencies": {
-    "@jimengio/url-model": "^0.0.1",
     "@types/lodash-es": "^4.17.3",
     "@types/node": "^13.1.2",
     "@types/qs": "^6.9.0",
@@ -26,7 +25,6 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
-    "@jimengio/url-model": "^0.0.1",
     "@types/react": "^16.8.16",
     "emotion": "^10.0.9",
     "react": "^16.8.6"

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,6 @@ import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, Method } from "ax
 import { ApiError, IJimuApiOption } from "./types";
 import { globalErrorMessages, globalStatusCodeErrorMessages } from "./messages";
 import { globalErrorCodeHandler, globalStatusCodeErrorHandler } from "./handlers";
-import { UrlModel } from "@jimengio/url-model";
 import { showError } from "./show-error";
 import { JimuApisEventBus, EJimuApiEvent } from "./event-bus";
 import Qs from "qs";
@@ -12,8 +11,7 @@ const instance = axios.create();
 const CancelToken = axios.CancelToken;
 
 export function setApiBaseUrl(baseUrl: string) {
-  const url = new UrlModel(baseUrl);
-  instance.defaults.baseURL = url.toString();
+  instance.defaults.baseURL = baseUrl;
 }
 
 export function getApiBaseUrl() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,11 +97,6 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@jimengio/url-model@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/@jimengio/url-model/-/url-model-0.0.1.tgz#9e92ffe980e6d929a95e344ef360c5bc44dd0645"
-  integrity sha512-rZVFq+Jl+CMzvb0E6i6M0Gth4Oebk4AdlexJmq8Hbpiy4v853CYzEHYNY8vowrbHqcdaadCmbK8AXNfDDVA9ag==
-
 "@types/lodash-es@^4.17.3":
   version "4.17.3"
   resolved "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"


### PR DESCRIPTION
`url-model` 主要还是进行格式化, 去掉就需要在设置时自己注意了. 考虑到是通用的 API 库, 为了一个小的格式化引入全部的代码, 并不合算.
