### PR TITLE
drop support for object params nesting; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/api-base",
-  "version": "0.3.0-a1",
+  "version": "0.3.0-a2",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.3",
     "@types/node": "^13.1.2",
-    "@types/qs": "^6.9.0",
     "@types/query-string": "^6.3.0",
     "@types/react": "^16.9.17",
     "dayjs": "^1.8.18",
@@ -32,7 +31,6 @@
   "dependencies": {
     "axios": "^0.19.0",
     "eventemitter3": "^4.0.0",
-    "lodash-es": "^4.17.15",
-    "qs": "^6.9.1"
+    "lodash-es": "^4.17.15"
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,6 @@ import { globalErrorMessages, globalStatusCodeErrorMessages } from "./messages";
 import { globalErrorCodeHandler, globalStatusCodeErrorHandler } from "./handlers";
 import { showError } from "./show-error";
 import { JimuApisEventBus, EJimuApiEvent } from "./event-bus";
-import Qs from "qs";
 import { notifyRequestStart, notifyRequestDone } from "./progress";
 
 const instance = axios.create();
@@ -119,23 +118,6 @@ const performRequest = async (option: IJimuApiOption) => {
 export const get = async <T = any>(option: IJimuApiOption): Promise<T> => {
   option.method = "GET";
   return performRequest(option);
-};
-
-/**
- * parse object params
- *
- * query: obj = {a: 1, b: 2} -> obj[a]=1&obj[b]=2
- * @param option
- */
-export const getWithNestedParams = async (option: IJimuApiOption) => {
-  option.paramsSerializer = function(params) {
-    return Qs.stringify(params, {
-      arrayFormat: "brackets",
-      encode: false,
-    });
-  };
-
-  return get(option);
 };
 
 export const post = async <T = any>(option: IJimuApiOption): Promise<T> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,11 +124,6 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/qs@^6.9.0":
-  version "6.9.0"
-  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.0.tgz#2a5fa918786d07d3725726f7f650527e1cfeaffd"
-  integrity sha512-c4zji5CjWv1tJxIZkz1oUtGcdOlsH3aza28Nqmm+uNDWBRHoMsjooBEN4czZp1V3iXPihE/VRUOBqg+4Xq0W4g==
-
 "@types/query-string@^6.3.0":
   version "6.3.0"
   resolved "https://registry.npmjs.org/@types/query-string/-/query-string-6.3.0.tgz#b6fa172a01405abcaedac681118e78429d62ea39"
@@ -407,11 +402,6 @@ prop-types@^15.6.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-qs@^6.9.1:
-  version "6.9.1"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
-  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
 query-string@*, query-string@^6.9.0:
   version "6.9.0"


### PR DESCRIPTION
not in use at current. 如果未来需要抽到这里, 建议用 `query-string`, 体积更新 https://gist.github.com/chenyong/e4299b3708ae6f7143bc286d0c2672c8 .